### PR TITLE
Rearrange provision steps

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -24,52 +24,71 @@ Vagrant.configure("2") do |config|
 # Get the VM up-to-date
     sudo apt-get update
 
-# Install opam and things for compiling xapi
-    sudo apt-get install -y opam m4 libxen-dev git
+# Install opam and dependencies for compiling xapi
+    sudo apt-get install -y opam m4 libxen-dev
     opam init -a --compiler=4.02.3 -y
+    eval `opam config env`
     opam remote add xs-opam git://github.com/xapi-project/xs-opam
-    opam install -y merlin ocp-indent ocp-index ocp-browser utop lwt_react depext camlp4
+    opam install -y lwt_react depext camlp4
     sudo opam depext -y xapi
+    # due to constraints missing from old libraries, pinning the lwt package is necessary for certain configurations
     opam pin add lwt 2.7.1
     opam install --deps-only xapi
 
-# Install editors
-    sudo apt-get install xubuntu-desktop gksu leafpad synaptic
-    sudo add-apt-repository -y "ppa:webupd8team/sublime-text-3"
-    sudo apt-add-repository -y "ppa:webupd8team/atom"
+# Verify xapi can be built
+    sudo apt-get install -y git
+    git clone git://github.com/xapi-project/xen-api
+    cd xen-api; ./configure; make; make test > test.log; cd ..
+
+# Install OCaml development tools
+    opam install -y merlin ocp-indent ocp-index ocp-browser utop
+    # ocp-index completion
+    sudo curl https://raw.githubusercontent.com/OCamlPro/ocp-index/master/tools/oct.sh -o /etc/bash_completion.d/oct
+
+# Install Sublime Text
+    sudo apt-add-repository -y "ppa:webupd8team/sublime-text-3"
+    sudo apt-get update
+    sudo apt-get install -y sublime-text-installer
+
+# Install Visual Studio Code
     curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg
     sudo mv microsoft.gpg /etc/apt/trusted.gpg.d/microsoft.gpg
     sudo sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/vscode stable main" > /etc/apt/sources.list.d/vscode.list'
-
     sudo apt-get update
-    sudo apt-get install -y atom emacs vim sublime-text-installer code
-
-    apm install nuclide ocaml-merlin language-ocaml
+    sudo apt-get install -y code
     code --install-extension hackwaly.ocaml
+    # fix launching from GUI
+    sudo sed -i s^/usr/share/code/code^/usr/share/code/code\\ --disable-gpu^g /usr/share/applications/code.desktop
+
+# Install Atom
+    sudo apt-add-repository -y "ppa:webupd8team/atom"
+    sudo apt-get update
+    sudo apt-get install -y atom
+    apm install nuclide ocaml-merlin language-ocaml
+    # fix launching from GUI
+    sudo sed -i s^/opt/atom/atom^/opt/atom/atom\\ --disable-gpu^g /usr/share/applications/atom.desktop
+
+# Install vim
+    sudo apt-get update
+    sudo apt-get install -y vim
+
+# Install emacs
+    sudo apt-get update
+    sudo apt-get install -y emacs
+
+# Automatically configure installed editor/s to use installed OCaml tools
     opam install user-setup
     opam user-setup install
-
-# Fix atom and VS code
-    sudo sed -i s^/opt/atom/atom^/opt/atom/atom\\ --disable-gpu^g /usr/share/applications/atom.desktop
-    sudo sed -i s^/usr/share/code/code^/usr/share/code/code\\ --disable-gpu^g /usr/share/applications/code.desktop
 
 # Fix gnome-terminal
     sudo localectl set-locale LANG="en_GB.utf8"
 
-# Docker
+# Install Docker - required by planex-buildenv
     sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
     sudo apt-add-repository 'deb https://apt.dockerproject.org/repo ubuntu-xenial main'
     sudo apt-get update
     sudo apt-get install -y docker-engine
     sudo usermod -aG docker vagrant
-
-# ocp-index completion
-    sudo curl https://raw.githubusercontent.com/OCamlPro/ocp-index/master/tools/oct.sh -o /etc/bash_completion.d/oct
-
-# Verify xapi can be built
-    git clone git://github.com/xapi-project/xen-api
-    eval `opam config env`
-    cd xen-api; ./configure; make; make test > test.log; cd ..
 
 # Reboot required to ensure locale and profile changes are picked up
 # We actually shut down because a `vagrant up` does some setting up.


### PR DESCRIPTION
Separate editor setup, and other steps, so that people
looking at the Vagrantfile can have a better idea of
what each step is doing, making it easier to pick out
the commands they need to set up their environment
locally.

Also, compile xapi before doing any editor setup, so we
can spot build errors faster.

Signed-off-by: Frederico Mazzone <frederico.mazzone@citrix.com>