### PR TITLE
Do not execute `opam depext` with `sudo`

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ In the `Vagrantfile`, `xapi` is built in order to verify that the environment ha
 Using `xenopsd` as an example, its dependencies must first be installed:
 
 ```
-sudo opam depext -y xenopsd
+opam depext -y xenopsd
 # do any pinning required for xenopsd using `opam pin add ...`
 opam install --deps-only xenopsd
 ```

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -30,7 +30,7 @@ Vagrant.configure("2") do |config|
     eval `opam config env`
     opam remote add xs-opam git://github.com/xapi-project/xs-opam
     opam install -y lwt_react depext camlp4
-    sudo opam depext -y xapi
+    opam depext -y xapi
     # due to constraints missing from old libraries, pinning the lwt package is necessary for certain configurations
     opam pin add lwt 2.7.1
     opam install --deps-only xapi


### PR DESCRIPTION
`opam depext` already uses `sudo` when it requires.

Signed-off-by: Frederico Mazzone <frederico.mazzone@citrix.com>