### PR TITLE
Refactor sed commands

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -58,7 +58,7 @@ Vagrant.configure("2") do |config|
     sudo apt-get install -y code
     code --install-extension hackwaly.ocaml
     # fix launching from GUI
-    sudo sed -i s^/usr/share/code/code^/usr/share/code/code\\ --disable-gpu^g /usr/share/applications/code.desktop
+    sudo sed -i -e 's^/usr/share/code/code^/usr/share/code/code --disable-gpu^g' /usr/share/applications/code.desktop
 
 # Install Atom
     sudo apt-add-repository -y "ppa:webupd8team/atom"
@@ -66,7 +66,7 @@ Vagrant.configure("2") do |config|
     sudo apt-get install -y atom
     apm install nuclide ocaml-merlin language-ocaml
     # fix launching from GUI
-    sudo sed -i s^/opt/atom/atom^/opt/atom/atom\\ --disable-gpu^g /usr/share/applications/atom.desktop
+    sudo sed -i -e 's^/opt/atom/atom^/opt/atom/atom --disable-gpu^g' /usr/share/applications/atom.desktop
 
 # Install vim
     sudo apt-get update


### PR DESCRIPTION
Change both sed commands to a different syntax
which does not require a double backslash.
This will allow the statement to be executed
manually without needing to omit one of the
backslashes.

Signed-off-by: Frederico Mazzone <frederico.mazzone@citrix.com>