### PR TITLE
Do not manually install conduit 0.14.5

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -49,8 +49,7 @@ Vagrant.configure("2") do |config|
     opam init -a --compiler=4.04.2 -y
     eval `opam config env`
     opam remote add xs-opam git://github.com/xapi-project/xs-opam
-    opam depext -y xapi conduit.0.14.5
-    opam install -y conduit.0.14.5
+    opam depext -y xapi
     opam install --deps-only xapi
 
 # Verify xapi can be built


### PR DESCRIPTION
No longer needed as the dependencies should now have been corrected
in xs-opam: https://github.com/xapi-project/xs-opam/pull/146

Signed-off-by: Frederico Mazzone <frederico.mazzone@citrix.com>